### PR TITLE
Fix memory leak in toast hooks

### DIFF
--- a/components/ui/use-toast.ts
+++ b/components/ui/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- fix the `useToast` effect so listeners aren't registered repeatedly

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e652261708325bde96e3a76c7dfe3